### PR TITLE
Add refined value KPIs

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -67,6 +67,8 @@
             <tr><td>Jetzt → Fertig um</td><td class="num"><span id="etaCell">–</span></td></tr>
             <tr><td>Gesamt Split (<span id="kpiUnitSplit">ISK</span>)</td><td class="num"><span id="kpiSplitTotal">–</span></td></tr>
             <tr><td>ISK pro Stunde Split (<span id="kpiUnitSplitPH">ISK</span>/h)</td><td class="num"><span id="kpiSplitPerHour">–</span></td></tr>
+            <tr><td>Refined Wert gesamt (<span id="kpiUnitRefined">ISK</span>)</td><td class="num"><span id="kpiRefinedTotal">–</span></td></tr>
+            <tr><td>Refined Wert pro Stunde (<span id="kpiUnitRefinedPH">ISK</span>/h)</td><td class="num"><span id="kpiRefinedPerHour">–</span></td></tr>
           </tbody>
         </table>
       </div>

--- a/public/script.js
+++ b/public/script.js
@@ -185,7 +185,7 @@ function updateCurrencyHeaders(){
 }
 function updateKPIUnitLabels(){
   var label = unitLabelOf(activeUnit);
-  ['kpiUnitSplit','kpiUnitSplitPH'].forEach(function(id){
+  ['kpiUnitSplit','kpiUnitSplitPH','kpiUnitRefined','kpiUnitRefinedPH'].forEach(function(id){
     var el = document.getElementById(id);
     if (el) el.textContent = label;
   });
@@ -253,10 +253,14 @@ function rerenderGroupTable() {
   var kB = document.getElementById('kpiBuyTotal'); if (kB) kB.textContent = totalBuy  > 0 ? fmtISK(totalBuy)  : '–';
   var kS = document.getElementById('kpiSellTotal'); if (kS) kS.textContent = totalSell > 0 ? fmtISK(totalSell) : '–';
   var kP = document.getElementById('kpiSplitTotal'); if (kP) kP.textContent = totalSplit > 0 ? fmtISK(totalSplit) : '–';
+  var kR = document.getElementById('kpiRefinedTotal'); if (kR) kR.textContent = totalSell > 0 ? fmtISK(totalSell) : '–';
   // ISK/h (Ø ISK/m³ × m³/s × 3600)
   var midPH  = (gEffRate > 0 && gTotalVolume > 0 && totalSplit> 0) ? (totalSplit/ gTotalVolume) * gEffRate * 3600 : NaN;
   var kPH = document.getElementById('kpiSplitPerHour');
   if (kPH) kPH.textContent = Number.isFinite(midPH) ? fmtISK(midPH) : '–';
+  var refinedPH = (gEffRate > 0 && gTotalVolume > 0 && totalSell > 0) ? (totalSell / gTotalVolume) * gEffRate * 3600 : NaN;
+  var kRPH = document.getElementById('kpiRefinedPerHour');
+  if (kRPH) kRPH.textContent = Number.isFinite(refinedPH) ? fmtISK(refinedPH) : '–';
 }
 // ——— Zeit ———
 function formatVerbose(totalSeconds) {

--- a/script.js
+++ b/script.js
@@ -185,7 +185,7 @@ function updateCurrencyHeaders(){
 }
 function updateKPIUnitLabels(){
   var label = unitLabelOf(activeUnit);
-  ['kpiUnitSplit','kpiUnitSplitPH'].forEach(function(id){
+  ['kpiUnitSplit','kpiUnitSplitPH','kpiUnitRefined','kpiUnitRefinedPH'].forEach(function(id){
     var el = document.getElementById(id);
     if (el) el.textContent = label;
   });
@@ -253,10 +253,14 @@ function rerenderGroupTable() {
   var kB = document.getElementById('kpiBuyTotal'); if (kB) kB.textContent = totalBuy  > 0 ? fmtISK(totalBuy)  : '–';
   var kS = document.getElementById('kpiSellTotal'); if (kS) kS.textContent = totalSell > 0 ? fmtISK(totalSell) : '–';
   var kP = document.getElementById('kpiSplitTotal'); if (kP) kP.textContent = totalSplit > 0 ? fmtISK(totalSplit) : '–';
+  var kR = document.getElementById('kpiRefinedTotal'); if (kR) kR.textContent = totalSell > 0 ? fmtISK(totalSell) : '–';
   // ISK/h (Ø ISK/m³ × m³/s × 3600)
   var midPH  = (gEffRate > 0 && gTotalVolume > 0 && totalSplit> 0) ? (totalSplit/ gTotalVolume) * gEffRate * 3600 : NaN;
   var kPH = document.getElementById('kpiSplitPerHour');
   if (kPH) kPH.textContent = Number.isFinite(midPH) ? fmtISK(midPH) : '–';
+  var refinedPH = (gEffRate > 0 && gTotalVolume > 0 && totalSell > 0) ? (totalSell / gTotalVolume) * gEffRate * 3600 : NaN;
+  var kRPH = document.getElementById('kpiRefinedPerHour');
+  if (kRPH) kRPH.textContent = Number.isFinite(refinedPH) ? fmtISK(refinedPH) : '–';
 }
 // ——— Zeit ———
 function formatVerbose(totalSeconds) {


### PR DESCRIPTION
## Summary
- show total refined value and refined value per hour in results
- keep units in sync with currency selection

## Testing
- `npm test`
- `node --check script.js`
- `node --check public/script.js`


------
https://chatgpt.com/codex/tasks/task_e_68b2cb2183348333a41f2d2864659ef5